### PR TITLE
Support Pending and Timeout outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 node-trx
 ========
 
-This is a Node utility for generating test results file in the TRX format.  This format is compliant with the namespace http://microsoft.com/schemas/VisualStudio/TeamTest/2010, found in full spec in %VSINSTALLDIR%\xml\Schemas\vstst.xsd. 
+This is a Node utility for generating test results files in the [Visual Studio Test Results File (TRX)](https://msdn.microsoft.com/en-us/library/jj155800(v=vs.120).aspx) format.
+
+The TRX file format is compliant with the namespace http://microsoft.com/schemas/VisualStudio/TeamTest/2010, found in full spec in `%VSINSTALLDIR%\xml\Schemas\vstst.xsd`. 
 
 This libary is a partial implementation of the XSD.
 
@@ -80,12 +82,18 @@ console.log(run);
 fs.writeFileSync('example.trx', run.toXml());
 ```
 
-
 Error information can be provided by including `errorMessage` and `errorStacktrace` properties in the result. Stacktrace must conform to the syntax `at [method signature] in [file path]:[line number]` or it will be picked up by Visual Studio.
 
 Standard output information can be included in the `output` property.
 
+### Unit tests
+
+Run `npm run test`.
+
 ### Releases
+
+0.5.0 - Added support for Pending and Timeout outcomes.
+
 0.4.0 - Added support for configuring Times tag.
 
 0.3.0 - Added support for configuring TestSetting and provides a default if not supplied.

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   },
   "devDependencies": {
     "mocha": "^1.21.4"
+  },
+  "scripts": {
+    "test": "mocha test/"
   }
 }

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -72,6 +72,41 @@ describe('formatter', function () {
           output: 'This is sample output for the unit test',
           errorMessage: 'This unit test failed for a bad reason',
           errorStacktrace: 'at test3() in c:\\tests\\test3.js:line 1'
+        })
+        .addResult({
+          executionId: 'a2c2aa1f-6ac5-4505-b441-b5927a925a87',
+          test: new UnitTest({
+            id: '3a9b1c2b-db55-49df-bbc4-2a03b052c981',
+            name: 'test 4',
+            methodName: 'test4',
+            methodCodeBase: 'testing-framework',
+            methodClassName: 'test4',
+            description: 'This is test 4'
+          }),
+          computerName: 'bmanci01',
+          outcome: 'Timeout',
+          duration: '00:00:44.7811567',
+          startTime: '2010-11-16T08:48:29.9072393-08:00',
+          endTime: '2010-11-16T08:49:16.9694381-08:00',
+          output: 'This is sample output for the unit test',
+          errorMessage: 'This unit test failed because it timed out',
+          errorStacktrace: 'at test4() in c:\\tests\\test4.js:line 1'
+        })
+        .addResult({
+          executionId: '6b8ddc5a-3a36-4d07-8e77-d2f5e1d3f14c',
+          test: new UnitTest({
+            id: '1c5288a9-26f1-4c44-913a-32024c99415e',
+            name: 'test 5',
+            methodName: 'test5',
+            methodCodeBase: 'testing-framework',
+            methodClassName: 'test5',
+            description: 'This is test 5'
+          }),
+          computerName: 'bmanci01',
+          outcome: 'Pending',
+          duration: '00:00:00.000',
+          startTime: '2010-11-16T08:48:29.9072393-08:00',
+          endTime: '2010-11-16T08:48:29.9072393-08:00'
         });
 
       actual = formatter.testRun(run);

--- a/test/test.trx
+++ b/test/test.trx
@@ -3,7 +3,7 @@
   <Times creation="2015-08-10T00:00:00.000Z" queuing="2015-08-10T00:00:00.000Z" start="2015-08-10T00:00:00.000Z" finish="2015-08-10T00:00:01.500Z"/>
   <TestSettings name="Default Test Settings" id="ce1a4cfb-64fa-4d63-8815-e9984737a62c"/>
   <ResultSummary outcome="Failed">
-    <Counters total="3" executed="3" passed="1" error="0" failed="1" timeout="0" aborted="0" inconclusive="1" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0"/>
+    <Counters total="5" executed="4" passed="1" error="0" failed="1" timeout="1" aborted="0" inconclusive="1" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="1"/>
   </ResultSummary>
   <TestDefinitions>
     <UnitTest id="89f81c68-a210-4e28-90ed-32d6f10d23f8" name="test 1">
@@ -21,6 +21,16 @@
       <Execution id="9d9b5fdc-f1fe-465b-bca6-49d50eeaf574"/>
       <TestMethod codeBase="testing-framework" className="test3" name="test3"/>
     </UnitTest>
+    <UnitTest id="3a9b1c2b-db55-49df-bbc4-2a03b052c981" name="test 4">
+      <Description>This is test 4</Description>
+      <Execution id="a2c2aa1f-6ac5-4505-b441-b5927a925a87"/>
+      <TestMethod codeBase="testing-framework" className="test4" name="test4"/>
+    </UnitTest>
+    <UnitTest id="1c5288a9-26f1-4c44-913a-32024c99415e" name="test 5">
+      <Description>This is test 5</Description>
+      <Execution id="6b8ddc5a-3a36-4d07-8e77-d2f5e1d3f14c"/>
+      <TestMethod codeBase="testing-framework" className="test5" name="test5"/>
+    </UnitTest>
   </TestDefinitions>
   <TestLists>
     <TestList id="8c84fa94-04c1-424b-9868-57a2d4851a1d" name="Results Not in a List"/>
@@ -30,6 +40,8 @@
     <TestEntry testId="89f81c68-a210-4e28-90ed-32d6f10d23f8" executionId="d8d6b688-c5e2-44c4-9c5c-a189875bd610" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d"/>
     <TestEntry testId="9ce212d1-e8c7-45d0-934f-e95d04c14dcb" executionId="71d40c44-01da-4b35-9f21-bf1cfff97e40" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d"/>
     <TestEntry testId="e458c13d-bf3d-44b3-9177-495d16ef73b8" executionId="9d9b5fdc-f1fe-465b-bca6-49d50eeaf574" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d"/>
+    <TestEntry testId="3a9b1c2b-db55-49df-bbc4-2a03b052c981" executionId="a2c2aa1f-6ac5-4505-b441-b5927a925a87" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d"/>
+    <TestEntry testId="1c5288a9-26f1-4c44-913a-32024c99415e" executionId="6b8ddc5a-3a36-4d07-8e77-d2f5e1d3f14c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d"/>
   </TestEntries>
   <Results>
     <UnitTestResult testId="89f81c68-a210-4e28-90ed-32d6f10d23f8" testName="test 1" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" computerName="bmanci01" outcome="Passed" startTime="2010-11-16T08:48:29.9072393-08:00" endTime="2010-11-16T08:49:16.9694381-08:00" duration="00:00:44.7811567" executionId="d8d6b688-c5e2-44c4-9c5c-a189875bd610"/>
@@ -43,5 +55,15 @@
         </ErrorInfo>
       </Output>
     </UnitTestResult>
+    <UnitTestResult testId="3a9b1c2b-db55-49df-bbc4-2a03b052c981" testName="test 4" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" computerName="bmanci01" outcome="Timeout" startTime="2010-11-16T08:48:29.9072393-08:00" endTime="2010-11-16T08:49:16.9694381-08:00" duration="00:00:44.7811567" executionId="a2c2aa1f-6ac5-4505-b441-b5927a925a87">
+      <Output>
+        <StdOut>This is sample output for the unit test</StdOut>
+        <ErrorInfo>
+          <Message>This unit test failed because it timed out</Message>
+          <StackTrace>at test4() in c:\tests\test4.js:line 1</StackTrace>
+        </ErrorInfo>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult testId="1c5288a9-26f1-4c44-913a-32024c99415e" testName="test 5" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" computerName="bmanci01" outcome="Pending" startTime="2010-11-16T08:48:29.9072393-08:00" endTime="2010-11-16T08:48:29.9072393-08:00" duration="00:00:00.000" executionId="6b8ddc5a-3a36-4d07-8e77-d2f5e1d3f14c"/>
   </Results>
 </TestRun>

--- a/trx.js
+++ b/trx.js
@@ -113,7 +113,7 @@ TestRun.prototype.addResult = function (params) {
 
 
 /**
- * Counter is defined bye the XSD
+ * Counter is defined by the XSD
  */
 function Counter() {
   this.total = 0;
@@ -137,21 +137,30 @@ function Counter() {
 /**
  * Increments the counter object values based on the outcome
  *
- * @param {string} outcome - outcome 'Passed', 'Failed', 'Inconclusive'
+ * @param {string} outcome - outcome 'Passed', 'Failed', 'Inconclusive', 'Timeout', 'Pending'
  */
 Counter.prototype.increment = function (outcome) {
   this.total += 1;
-  this.executed += 1;
 
   switch (outcome) {
     case 'Passed':
+      this.executed += 1;
       this.passed += 1;
       break;
     case 'Failed':
+      this.executed += 1;
       this.failed += 1;
       break;
     case 'Inconclusive':
+      this.executed += 1;
       this.inconclusive += 1;
+      break;
+    case 'Timeout':
+      this.executed += 1;
+      this.timeout += 1;
+      break;
+    case 'Pending':
+      this.pending += 1;
       break;
   }
 }


### PR DESCRIPTION
Tests with `Pending` (to be implemented) or `Timeout` outcomes would not correctly increment the summary counters.

I assume that a Pending test, doesn't count as 'executed', since there's nothing to execute. Therefore I have changed the default logic of always increasing the executed counter. The counter now includes also counts for Pending and Timeout outcomes, as confirmed with the updated unit test.

Also updated the README with a TRX info reference, instructions how to run the unit tests, and included a version bump. Let me know if you want to have this revised.