### PR TITLE
Adding test owners for each test

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -22,6 +22,7 @@ run = new TestRun({
       methodName: 'test1',
       methodCodeBase: 'testing-framework',
       methodClassName: 'test1',
+      owners: [{name: 'testOwner1'}, {name: 'testOwner2'}],
       description: 'This is test 1'
     }),
     computerName: computerName,

--- a/formatter.js
+++ b/formatter.js
@@ -94,6 +94,11 @@ function buildTestDefinition(parent, testDefinition) {
     xml.ele('Description', testDefinition.description);
   }
 
+  if(testDefinition.owners) {
+    var owners = xml.ele('Owners');
+    buildArray(testDefinition.owners, owners, buildTestOwners);
+  }
+   
   xml.ele('Execution', {id: testDefinition.executionId}, null);
   xml.ele('TestMethod')
     .att('codeBase', testDefinition.methodCodeBase)
@@ -112,6 +117,11 @@ function buildTestEntry(parent, testEntry) {
     .att('testId', testEntry.testId)
     .att('executionId', testEntry.executionId)
     .att('testListId', testEntry.testListId);
+}
+
+function buildTestOwners(parent, owner) {
+  var xml = parent.ele('Owner', owner)
+    .att('name', owner.name);
 }
 
 function buildTestResult(parent, result) {

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -33,6 +33,7 @@ describe('formatter', function () {
             methodName: 'test1',
             methodCodeBase: 'testing-framework',
             methodClassName: 'test1',
+            owners: [{name: 'testOwner'}],
             description: 'This is test 1'
           }),
           computerName: 'bmanci01',
@@ -133,7 +134,6 @@ describe('formatter', function () {
 
       actual = formatter.testRun(run);
       expected = fs.readFileSync('test/test.trx', 'ascii');
-      
       assert.equal(expected, actual);
     });
   });

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -134,6 +134,7 @@ describe('formatter', function () {
 
       actual = formatter.testRun(run);
       expected = fs.readFileSync('test/test.trx', 'ascii');
+
       assert.equal(expected, actual);
     });
   });

--- a/test/test.trx
+++ b/test/test.trx
@@ -10,6 +10,9 @@
   <TestDefinitions>
     <UnitTest id="89f81c68-a210-4e28-90ed-32d6f10d23f8" name="test 1">
       <Description>This is test 1</Description>
+      <Owners>
+        <Owner name="testOwner"/>
+      </Owners>
       <Execution id="d8d6b688-c5e2-44c4-9c5c-a189875bd610"/>
       <TestMethod codeBase="testing-framework" className="test1" name="test1"/>
     </UnitTest>

--- a/trx.js
+++ b/trx.js
@@ -233,7 +233,6 @@ function Deployment(params) {
   this.enabled = params.enabled
 }
 
-
 /**
  * A TestList as defined by the XSD type `TestListType`
  *
@@ -245,6 +244,18 @@ function TestList(params) {
   this.id = params.id || uuid.v4();
   this.name = params.name;
 }
+
+
+/**
+ * An Owner as defined by the XSD type `OwnerType`
+ *
+ * @param {object} params
+ * @config {string} name - name of the owner
+ */
+function Owner(params) {
+  this.name = params.name;
+}
+
 
 /**
  * System list for 'Results Not in a List'
@@ -266,6 +277,7 @@ TestList.AllLoadedResults = new TestList({id: '19431567-8539-422a-85d7-44ee4e166
  * @config {string} methodCodeBase
  * @config {string} methodClassName
  * @config {string} [id]
+ * @config {Owner[]} owners
  */
 function UnitTest(params) {
   this.id = params.id || uuid.v4();
@@ -274,6 +286,7 @@ function UnitTest(params) {
   this.methodName = params.methodName;
   this.methodCodeBase = params.methodCodeBase;
   this.methodClassName = params.methodClassName;
+  this.owners = params.owners;
   this.description = params.description;
 }
 


### PR DESCRIPTION
Currently node-trx does not support having test owners as a property of unit test. Adding this so generated trx files can be used in situations where test owners must be specified.

@bmancini55 Please review this when you're available. Thanks!